### PR TITLE
Datacollect

### DIFF
--- a/fido_app/models.py
+++ b/fido_app/models.py
@@ -12,7 +12,6 @@ class User(db.Model, UserMixin):
     # User info
     email = db.Column(db.String(80), unique=True, nullable=False)
     display_name = db.Column(db.String(160), unique=False, nullable=False)
-    device_id = db.Column(db.String(64), unique=True, nullable=False)
     icon_url = db.Column(db.String(2083))
     high_score = db.Column(db.Integer, default=0)
 

--- a/fido_app/models.py
+++ b/fido_app/models.py
@@ -12,6 +12,7 @@ class User(db.Model, UserMixin):
     # User info
     email = db.Column(db.String(80), unique=True, nullable=False)
     display_name = db.Column(db.String(160), unique=False, nullable=False)
+    device_id = db.Column(db.String(64), unique=True, nullable=False)
     icon_url = db.Column(db.String(2083))
     high_score = db.Column(db.Integer, default=0)
 
@@ -25,6 +26,9 @@ class User(db.Model, UserMixin):
     sign_count = db.Column(db.Integer, default=0)
     rp_id = db.Column(db.String(253), nullable=True)
 
+    # Page interaction info
+    tokens = db.relationship('Token', lazy=True, backref=db.backref('user', lazy=True))
+
     def __repr__(self):
         return f'<User {self.display_name} {self.username}>'
 
@@ -35,3 +39,33 @@ class User(db.Model, UserMixin):
     def check_password(self, password):
         '''Checks if the given plaintext password matches the salt and hash for the given user'''
         return check_password_hash(self.password_hash, password)
+
+
+class Session(db.Model):
+    '''
+    Model associating users with persistent cookie tokens;
+    'user' property is implicitly created by relationship in User class
+    '''
+
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    token = db.Column(db.String(32), unique=False, nullable=False)
+    
+    interactions = db.relationship('Interaction', lazy=True, backref=db.backref('session', lazy=True))
+
+    def __repr__(self):
+        return f'<User id {self.user_id} has session token {self.token}>'
+    
+    
+class Interaction(db.Model):
+    '''
+    Model associating persistent cookie token with individual page interactions;
+    'session' property is implicitly created by relationship in Session class
+    '''
+
+    session_token = db.column(db.String(32), db.ForeignKey('session.token'), nullable=False)
+    event = db.Column(db.Enum('focus', 'click', 'submit'), nullable=False, validate_strings=True)
+    page = db.Column(db.Enum('register', 'login'), nullable=False, validate_strings=True)
+    timestamp = db.Column(db.DateTime, unique=False, nullable=False)
+
+    def __repr__(self):
+        return f'<Session token {self.user_id} triggered event {self.event_type} at {self.timestamp}>'

--- a/fido_app/models.py
+++ b/fido_app/models.py
@@ -26,7 +26,7 @@ class User(db.Model, UserMixin):
     rp_id = db.Column(db.String(253), nullable=True)
 
     # Page interaction info
-    tokens = db.relationship('Token', lazy=True, backref=db.backref('user', lazy=True))
+    sessions = db.relationship('Session', lazy=True, backref=db.backref('user', lazy=True))
 
     def __repr__(self):
         return f'<User {self.display_name} {self.username}>'
@@ -49,7 +49,7 @@ class Session(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
-    token = db.Column(db.String(32), unique=False, nullable=False)
+    token = db.Column(db.String(32), unique=True, nullable=False)
     
     interactions = db.relationship('Interaction', lazy=True, backref=db.backref('session', lazy=True))
 
@@ -65,10 +65,10 @@ class Interaction(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     
-    session_token = db.column(db.String(32), db.ForeignKey('session.token'))
+    session_token = db.Column(db.String(32), db.ForeignKey('session.token'))
     event = db.Column(db.Enum('focus', 'click', 'submit'), nullable=False, validate_strings=True)
     page = db.Column(db.Enum('register', 'login'), nullable=False, validate_strings=True)
     timestamp = db.Column(db.DateTime, unique=False, nullable=False)
 
     def __repr__(self):
-        return f'<Session token {self.session_token} triggered event {self.event} at {self.timestamp}>'
+        return f'<Session token {self.session_token} triggered event {self.event} at {self.timestamp}> on page {self.page}'

--- a/fido_app/models.py
+++ b/fido_app/models.py
@@ -67,4 +67,4 @@ class Interaction(db.Model):
     timestamp = db.Column(db.DateTime, unique=False, nullable=False)
 
     def __repr__(self):
-        return f'<Session token {self.user_id} triggered event {self.event_type} at {self.timestamp}>'
+        return f'<Session token {self.session_token} triggered event {self.event} at {self.timestamp}>'

--- a/fido_app/models.py
+++ b/fido_app/models.py
@@ -46,7 +46,9 @@ class Session(db.Model):
     'user' property is implicitly created by relationship in User class
     '''
 
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    id = db.Column(db.Integer, primary_key=True)
+    
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     token = db.Column(db.String(32), unique=False, nullable=False)
     
     interactions = db.relationship('Interaction', lazy=True, backref=db.backref('session', lazy=True))
@@ -61,7 +63,9 @@ class Interaction(db.Model):
     'session' property is implicitly created by relationship in Session class
     '''
 
-    session_token = db.column(db.String(32), db.ForeignKey('session.token'), nullable=False)
+    id = db.Column(db.Integer, primary_key=True)
+    
+    session_token = db.column(db.String(32), db.ForeignKey('session.token'))
     event = db.Column(db.Enum('focus', 'click', 'submit'), nullable=False, validate_strings=True)
     page = db.Column(db.Enum('register', 'login'), nullable=False, validate_strings=True)
     timestamp = db.Column(db.DateTime, unique=False, nullable=False)


### PR DESCRIPTION
Schema:
- User(...*existing attributes*..., tokens*)
- Session(user ID, token, interactions*, user**)
- Interaction(session token, event, page, timestamp, session**)

*denotes a one-to-many relationship with the table below it--i.e., between User and Session, and Session and Interaction. In SQLAlchemy, this gives us a convenient way to retrieve, say, a list of all Interaction tuples associated with a particular user-token pair, by reading the session.interactions attribute.

**denotes attributes that are implicitly created by declaring relationships between tables. SQLAlchemy provides this as a convenient way to retrieve the corresponding "one" in a one-to-many relationship, matched on the specified foreign key.